### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Reactive Flick Search
+# Reactive Flick Search
 
 An application that demonstrates how to implement the MVVM pattern in iOS using [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa). I've also [re-implemented this application in Swift](https://github.com/ColinEberhardt/ReactiveSwiftFlickrSearch).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
